### PR TITLE
bump crystal requirement for 1.0 compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ authors:
   - Brian J. Cardiff <bcardiff@manas.tech>
   - Franciscello <ftarulla@manas.tech>
 
-crystal: 0.31.1
+crystal: ">= 0.31.1"
 
 license: MIT


### PR DESCRIPTION
Fixes #3 

ICR is unable to build when using any recent version of Crystal due to the version requirement.