### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.1 (2021-07-21)
+
+- Fix compatibility with Crystal >= 0.31.1 in `shard.yml` ([#5](https://github.com/crystal-lang/crystal-readline/pull/5), thanks @HashNuke)
+- Add Troubleshooting section to README ([#2](https://github.com/crystal-lang/crystal-readline/pull/2), thanks @ryanprior)
+
 # v0.1.0 (2019-10-22)
 
 - Extract from Crystal 0.31.1 std-lib.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: readline
-version: 0.1.0
+version: 0.1.1
 
 libraries:
   readline: "*"


### PR DESCRIPTION
Let's cut a new release to let the updated `crystal` version restriction (#5) take effect.

I figured making it a patch release is sufficient, since the changes are only documentation and packaging.