### PR TITLE
Added read_history

### DIFF
--- a/src/readline.cr
+++ b/src/readline.cr
@@ -7,6 +7,7 @@ lib LibReadline
 
   fun readline(prompt : UInt8*) : UInt8*
   fun add_history(line : UInt8*)
+  fun read_history(fname : UInt8*) : Int
   fun rl_bind_key(key : Int, f : Int, Int -> Int) : Int
   fun rl_unbind_key(key : Int) : Int
 


### PR DESCRIPTION
Hi!
Thank you for creating this helpful library!

I am using this library for a tool that calls chatgpt API from the command line. I needed a function to read history from a file at the start of the tool. That was the `read_history` function.

```crystal
LibReadline.read_history(".chatgpt_history")
```

I believe that by using a tool like [crystal_lib](https://github.com/crystal-lang/crystal_lib), the bindings for these functions can be generated automatically to a large extent. However, since this project has a small number of functions that work for sure, I was wondering if users could just pull requests for the functions they need.
What I would like is read_history. Best regards.

Thank you.