### PR TITLE
add support for initial_text

### DIFF
--- a/spec/readline_spec.cr
+++ b/spec/readline_spec.cr
@@ -4,6 +4,7 @@ describe Readline do
   typeof(Readline.readline)
   typeof(Readline.readline("Hello", true))
   typeof(Readline.readline(prompt: "Hello"))
+  typeof(Readline.readline(prompt: "Hello", initial_text: "World"))
   typeof(Readline.readline(add_history: false))
   typeof(Readline.line_buffer)
   typeof(Readline.point)


### PR DESCRIPTION
This uses rl_startup_hook to set the initial text in a readline input field.

Use cases:
- interactive renaming
- searching for content while allowing modifications to the initial query

This change is backward compatible.
If initial_text is not explicitly set, the added functionality in this commit will not be triggered.